### PR TITLE
SSH Remote support for remote linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
-    "jsonc-parser": "^2.2.1"
+    "jsonc-parser": "^2.2.1",
+    "ssh-config": "^4.0.2"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { promisify } from 'util';
 import { dirname } from 'path';
 import { detectInstallation } from './installation';
 import { IWTProfile, IWTInstallation } from './interfaces';
-import { profile } from 'console';
+import { resolveSSHHostName } from './ssh';
 
 let installation: IWTInstallation;
 
@@ -50,7 +50,8 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
         // Changing paths on Windows seems tricky
         args.push('ssh', host);
       } else {
-        args.push('ssh', '-t', host, `cd ${uri.path}; exec \\$SHELL -l`);
+        const remoteMachine = await resolveSSHHostName(host);
+        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec $SHELL -l`);
       }
     } else {
       let cwd = uri.fsPath;

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,0 +1,49 @@
+import { readFile } from "fs";
+import * as vscode from "vscode";
+const SSHConfig = require("ssh-config");
+
+interface IParam {
+  param: string;
+  value: string;
+  config: Array<IParam>;
+}
+
+export function resolveSSHHostName(host: string) {
+  return new Promise<any | undefined>(function (resolve, reject) {
+    // get path from remote-ssh-extension config file
+    const remoteSettingsPath: string | undefined = vscode.workspace
+      .getConfiguration("remote.SSH")
+      .get("configFile");
+    if (remoteSettingsPath) {
+      readFile(remoteSettingsPath, function (err, contents) {
+        if (!err) {
+          let resolvedHost = "";
+          // parse file
+          const config: Array<IParam> = SSHConfig.parse(contents.toString());
+          const settings = config.find((x) => x.param.toLowerCase() === "host" && x.value === host);
+
+          if (settings) {
+            const hostname = settings.config.find((x) => x.param.toLowerCase() === "hostname");
+            if (hostname && hostname.value) {
+              resolvedHost += `${hostname.value}`;
+            }
+            const user = settings.config.find((x) => x.param.toLowerCase() === "user");
+            if (user && user.value && hostname?.value) {
+              resolvedHost = `${user.value}@` + resolvedHost;
+            }
+          }
+
+          if (resolvedHost === "") {
+            resolvedHost = host;
+          }
+
+          return resolve(resolvedHost);
+        } else {
+          return resolve(host);
+        }
+      });
+    } else {
+      return resolve(host);
+    }
+  });
+}

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,5 +1,6 @@
-import { readFile } from "fs";
+import { readFile, exists } from 'fs';
 import * as vscode from "vscode";
+import { promisify } from 'util';
 const SSHConfig = require("ssh-config");
 
 interface IParam {
@@ -8,42 +9,45 @@ interface IParam {
   config: Array<IParam>;
 }
 
-export function resolveSSHHostName(host: string) {
-  return new Promise<any | undefined>(function (resolve, reject) {
-    // get path from remote-ssh-extension config file
-    const remoteSettingsPath: string | undefined = vscode.workspace
-      .getConfiguration("remote.SSH")
-      .get("configFile");
-    if (remoteSettingsPath) {
-      readFile(remoteSettingsPath, function (err, contents) {
-        if (!err) {
-          let resolvedHost = "";
-          // parse file
-          const config: Array<IParam> = SSHConfig.parse(contents.toString());
-          const settings = config.find((x) => x.param.toLowerCase() === "host" && x.value === host);
+export async function resolveSSHHostName(host: string): Promise<string> {
+  // get path from remote-ssh-extension config file
+  const remoteSettingsPath: string | undefined = vscode.workspace
+    .getConfiguration("remote.SSH")
+    .get("configFile");
 
-          if (settings) {
-            const hostname = settings.config.find((x) => x.param.toLowerCase() === "hostname");
-            if (hostname && hostname.value) {
-              resolvedHost += `${hostname.value}`;
-            }
-            const user = settings.config.find((x) => x.param.toLowerCase() === "user");
-            if (user && user.value && hostname?.value) {
-              resolvedHost = `${user.value}@` + resolvedHost;
-            }
-          }
+  if (!remoteSettingsPath) {
+    return host;
+  }
 
-          if (resolvedHost === "") {
-            resolvedHost = host;
-          }
+  const pathExists = await promisify(exists)(remoteSettingsPath);
+  if (!pathExists) {
+    throw Error('Expected remote ssh settings file does not exist: ' + remoteSettingsPath);
+  }
 
-          return resolve(resolvedHost);
-        } else {
-          return resolve(host);
-        }
-      });
-    } else {
-      return resolve(host);
+  const rawString = (await promisify(readFile)(remoteSettingsPath))?.toString();
+  if (!rawString) {
+    throw Error('Could not read remote ssh settings file');
+  }
+
+  // parse content
+  const config: Array<IParam> = SSHConfig.parse(rawString);
+  const settings = config.find((x) => x.param.toLowerCase() === "host" && x.value === host);
+
+  let resolvedHost = "";
+  if (settings) {
+    const hostname = settings.config.find((x) => x.param.toLowerCase() === "hostname");
+    if (hostname && hostname.value) {
+      resolvedHost += `${hostname.value}`;
     }
-  });
+    const user = settings.config.find((x) => x.param.toLowerCase() === "user");
+    if (user && user.value && hostname?.value) {
+      resolvedHost = `${user.value}@` + resolvedHost;
+    }
+  }
+
+  if (resolvedHost === "") {
+    resolvedHost = host;
+  }
+
+  return resolvedHost;
 }


### PR DESCRIPTION
Implement and test ssh remote for remote linux:
 - obtain hostname and username (with the host provided by the uri) for accessing linux remote machine through the config file of ms-vscode-remote.remote-ssh.
 - fix command given to "wt.exe ssh"

Closes #15 
