### PR TITLE
fix ssh into windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,8 +61,8 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       const remoteMachine = await resolveSSHHostName(host);
       if (isWindows) {
         // remove first /
-        const uri_windows = uri.path.substring(1, uri.path.length);
-        args.push('ssh', remoteMachine, `cd ${uri_windows} && powershell.exe`);
+        const uriWindows = uri.path.substring(1, uri.path.length);
+        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\;${vscode.env.shell}`);
       } else {
         args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec $SHELL -l`);
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
     if (uri.authority.startsWith('ssh-remote+')) {
       // Handle SSH remotes first
       const host = uri.authority.split('+')[1];
-      const isWindows = !!uri.path.match(/^\/[a-z]:\//);
+      const isWindows = !!uri.path.match(/^\/[a-zA-Z]:\/.*$/);
       if (isWindows) {
         // Changing paths on Windows seems tricky
         args.push('ssh', host);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,11 +58,11 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       // Handle SSH remotes first
       const host = uri.authority.split('+')[1];
       const isWindows = !!uri.path.match(/^\/[a-zA-Z]:\/.*$/);
+      const remoteMachine = await resolveSSHHostName(host);
       if (isWindows) {
         // Changing paths on Windows seems tricky
-        args.push('ssh', host);
+        args.push('ssh', remoteMachine);
       } else {
-        const remoteMachine = await resolveSSHHostName(host);
         args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec $SHELL -l`);
       }
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,8 +60,9 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       const isWindows = !!uri.path.match(/^\/[a-zA-Z]:\/.*$/);
       const remoteMachine = await resolveSSHHostName(host);
       if (isWindows) {
-        // Changing paths on Windows seems tricky
-        args.push('ssh', remoteMachine);
+        // remove first /
+        const uri_windows = uri.path.substring(1, uri.path.length);
+        args.push('ssh', remoteMachine, `cd ${uri_windows} && powershell.exe`);
       } else {
         args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec $SHELL -l`);
       }


### PR DESCRIPTION
- Fix regex expression that was trying to detect if uri.path was a windows path.
- use resolveSSHHostName to detect username if needed in windows remotes too
- convert uri.path to a windows path