### PR TITLE
fixes for ssh into windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
     if (uri.authority.startsWith('ssh-remote+')) {
       // Handle SSH remotes first
       const host = uri.authority.split('+')[1];
-      const isWindows = !!uri.path.match(/^\/[a-z]:\//);
+      const isWindows = !!uri.path.match(/^\/[a-zA-Z]:\/.*$/);
       if (isWindows) {
         // Changing paths on Windows seems tricky
         args.push('ssh', host);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,11 +58,11 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       // Handle SSH remotes first
       const host = uri.authority.split('+')[1];
       const isWindows = !!uri.path.match(/^\/[a-zA-Z]:\/.*$/);
+      const remoteMachine = await resolveSSHHostName(host);
       if (isWindows) {
         // Changing paths on Windows seems tricky
-        args.push('ssh', host);
+        args.push('ssh', remoteMachine);
       } else {
-        const remoteMachine = await resolveSSHHostName(host);
         args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec $SHELL -l`);
       }
     } else {


### PR DESCRIPTION
- Fix regex expression that was trying to detect if uri.path was a windows path.
- use resolveSSHHostName to detect username if needed in windows remotes too