### PR TITLE
use terminal.integrated.shell.linux/windows as shell in ssh

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { dirname } from 'path';
 import { detectInstallation } from './installation';
 import { IWTProfile, IWTInstallation } from './interfaces';
 import { resolveSSHHostName } from './ssh';
-import { getShell, OS } from './shells';
+import { shellScript } from './shells';
 
 let installation: IWTInstallation | undefined;
 
@@ -63,9 +63,9 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       if (isWindows) {
         // remove first /
         const uriWindows = uri.path.substring(1, uri.path.length);
-        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\;${getShell(OS.WINDOWS)}`);
+        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\; ${shellScript('windows')}`);
       } else {
-        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec ${getShell(OS.LINUX)} -l`);
+        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && ${shellScript('linuxbase')}`);
       }
     } else {
       let cwd = uri.fsPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { dirname } from 'path';
 import { detectInstallation } from './installation';
 import { IWTProfile, IWTInstallation } from './interfaces';
 import { resolveSSHHostName } from './ssh';
+import { getShell, OS } from './shells';
 
 let installation: IWTInstallation | undefined;
 
@@ -62,9 +63,9 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       if (isWindows) {
         // remove first /
         const uriWindows = uri.path.substring(1, uri.path.length);
-        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\;${vscode.env.shell}`);
+        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\;${getShell(OS.WINDOWS)}`);
       } else {
-        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec $SHELL -l`);
+        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && exec ${getShell(OS.LINUX)} -l`);
       }
     } else {
       let cwd = uri.fsPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { dirname } from 'path';
 import { detectInstallation } from './installation';
 import { IWTProfile, IWTInstallation } from './interfaces';
 import { resolveSSHHostName } from './ssh';
-import { shellScript } from './shells';
+import { shellScript, OS } from './shells';
 
 let installation: IWTInstallation | undefined;
 
@@ -63,9 +63,9 @@ async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
       if (isWindows) {
         // remove first /
         const uriWindows = uri.path.substring(1, uri.path.length);
-        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\; ${shellScript('windows')}`);
+        args.push('ssh', remoteMachine, `powershell -NoExit -Command cd ${uriWindows}\\; ${shellScript(OS.WINDOWS)}`);
       } else {
-        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && ${shellScript('linuxbase')}`);
+        args.push('ssh', '-t', remoteMachine, `cd ${uri.path} && ${shellScript(OS.UNIXLIKE)}`);
       }
     } else {
       let cwd = uri.fsPath;

--- a/src/shells.ts
+++ b/src/shells.ts
@@ -33,15 +33,15 @@ function getShell(os: OSShellKey) {
 
 export function shellScript(os: OS) {
   if (os === OS.WINDOWS) {
-    return `&{${getShell(OSShellKey.WINDOWS)}} 2> $null`;
+    return `${getShell(OSShellKey.WINDOWS)}`;
   }
 
   if (os === OS.UNIX) {
-    return `(${getShell(OSShellKey.LINUX)} 2> /dev/null || exec $SHELL)`;
+    return `${getShell(OSShellKey.LINUX)} || exec $SHELL`;
   }
 
   if (os === OS.UNIXLIKE) {
-    return `( if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi 2> /dev/null  || exec $SHELL )`;
+    return `if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi || exec $SHELL`;
   }
 
   return '';

--- a/src/shells.ts
+++ b/src/shells.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+export enum OS {
+  WINDOWS = 1,
+  LINUX = 2
+}
+
+const windowsDefaultShell = 'powershell.exe';
+const linuxDefaultShell = '/bin/bash';
+
+
+export function getShell(os: OS) {
+  const integratedShell = vscode.workspace.getConfiguration('terminal.integrated.shell');
+
+  if (os === OS.WINDOWS) {
+    const windowsShell = integratedShell?.get<string>('windows');
+    if (windowsShell) {
+      return windowsShell;
+    }
+    return windowsDefaultShell;
+  }
+
+  if (os === OS.LINUX) {
+    const linuxShell = integratedShell?.get<string>('linux');
+    if (linuxShell) {
+      return linuxShell;
+    }
+    return linuxDefaultShell;
+  }
+}

--- a/src/shells.ts
+++ b/src/shells.ts
@@ -37,7 +37,7 @@ export function shellScript(os: OS) {
   }
 
   if (os === OS.UNIX) {
-    return `(${getShell(OSShellKey.LINUX)} 2> /dev/null || exec $SHELL) 2> /dev/null`;
+    return `(${getShell(OSShellKey.LINUX)} 2> /dev/null || exec $SHELL)`;
   }
 
   if (os === OS.UNIXLIKE) {

--- a/src/shells.ts
+++ b/src/shells.ts
@@ -1,16 +1,25 @@
 import * as vscode from 'vscode';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-type systems = 'windows' | 'linux' | 'osx' | 'linuxbase';
+export enum OS {
+  WINDOWS,
+  UNIX,
+  UNIXLIKE
+}
+
+enum OSShellKey {
+  WINDOWS = 'windows',
+  LINUX = 'linux',
+  MACOS = 'osx'
+}
 
 // Default shells in vscode
 const defaultShells = {
   windows: 'powershell.exe',
   linux: '$SHELL',
-  osx: '$SHELL'
+  osx: '$SHELL',
 };
 
-function getShell(os: Exclude<systems, 'linuxbase'>) {
+function getShell(os: OSShellKey) {
 
   const integratedShell = vscode.workspace.getConfiguration('terminal.integrated.shell');
 
@@ -22,17 +31,17 @@ function getShell(os: Exclude<systems, 'linuxbase'>) {
   return defaultShells[os];
 }
 
-export function shellScript(os: Exclude<systems, 'osx'>) {
-  if (os === 'windows') {
-    return `${getShell('windows')}`;
+export function shellScript(os: OS) {
+  if (os === OS.WINDOWS) {
+    return `${getShell(OSShellKey.WINDOWS)}`;
   }
 
-  if (os === 'linux') {
-    return `${getShell('linux')} || exec $SHELL -l`;
+  if (os === OS.UNIX) {
+    return `${getShell(OSShellKey.LINUX)} || exec $SHELL -l`;
   }
 
-  if (os === 'linuxbase') {
-    return `if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell('osx')}\\; else ${getShell('linux')}\\; fi || exec $SHELL -l`;
+  if (os === OS.UNIXLIKE) {
+    return `if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi || exec $SHELL -l`;
   }
 
   return '';

--- a/src/shells.ts
+++ b/src/shells.ts
@@ -37,11 +37,11 @@ export function shellScript(os: OS) {
   }
 
   if (os === OS.UNIX) {
-    return `(${getShell(OSShellKey.LINUX)} 2> /dev/null || exec $SHELL -l) 2> /dev/null`;
+    return `(${getShell(OSShellKey.LINUX)} 2> /dev/null || exec $SHELL) 2> /dev/null`;
   }
 
   if (os === OS.UNIXLIKE) {
-    return `( if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi 2> /dev/null  || exec $SHELL -l )`;
+    return `( if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi 2> /dev/null  || exec $SHELL )`;
   }
 
   return '';

--- a/src/shells.ts
+++ b/src/shells.ts
@@ -33,15 +33,15 @@ function getShell(os: OSShellKey) {
 
 export function shellScript(os: OS) {
   if (os === OS.WINDOWS) {
-    return `${getShell(OSShellKey.WINDOWS)}`;
+    return `&{${getShell(OSShellKey.WINDOWS)}} 2> $null`;
   }
 
   if (os === OS.UNIX) {
-    return `${getShell(OSShellKey.LINUX)} || exec $SHELL -l`;
+    return `(${getShell(OSShellKey.LINUX)} 2> /dev/null || exec $SHELL -l) 2> /dev/null`;
   }
 
   if (os === OS.UNIXLIKE) {
-    return `if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi || exec $SHELL -l`;
+    return `( if [[ "$(uname -s)" = "Darwin" ]]\\; then ${getShell(OSShellKey.MACOS)}\\; else ${getShell(OSShellKey.LINUX)}\\; fi 2> /dev/null  || exec $SHELL -l )`;
   }
 
   return '';


### PR DESCRIPTION
- use terminal.integrated.shell.linux/windows/osx as shell on a remote machine connected via ssh

P.S i didn't find a way of passing a command to wsl in via wt args