### PR TITLE
Add support for devcontainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The context menu also works in [WSL remotes](https://marketplace.visualstudio.co
 
 Opening the terminal when in a [SSH remote](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) workspace will ssh into the remote in Windows Terminal.
 
+**devcontainer support**
+
+Opening the terminal when in a [devcontainer remote](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) workspaces will `docker exec` into the remote in Windows Terminal.
+
 **Several commands for launching WT**
 
 See the Feature Contributions tab for a full list of commands that can be setup with [custom keybindings](https://code.visualstudio.com/docs/getstarted/keybindings).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The context menu also works in [WSL remotes](https://marketplace.visualstudio.co
 
 Opening the terminal when in a [SSH remote](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) workspace will ssh into the remote in Windows Terminal.
 
-**devcontainer support**
+**Dev container support**
 
 Opening the terminal when in a [devcontainer remote](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) workspaces will `docker exec` into the remote in Windows Terminal.
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,0 +1,12 @@
+import { exec } from 'child_process';
+
+export function runDockerCommand(command: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    exec(`docker ${command}`, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(stdout.trim());
+    });
+  });
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
 import * as jsoncParser from 'jsonc-parser';
 import { promisify } from 'util';
 import { readFile, exists } from 'fs';
@@ -15,4 +17,12 @@ export async function getSettingsContents(settingsPath: string): Promise<IWTSett
   }
 
   return jsoncParser.parse(rawString) as IWTSettings;
+}
+
+const readLocalFile = promisify(readFile);
+export async function getVscodeQuality(): Promise<String> {
+  const jsonPath = path.join(vscode.env.appRoot, 'product.json');
+  const raw = await readLocalFile(jsonPath, 'utf8');
+  const json = JSON.parse(raw);
+  return json.quality;
 }


### PR DESCRIPTION
Add support for launching Windows Terminal in a Remote-Container instance by finding the matching container from the running containers and launching WT with a `docker exec` command.