### PR TITLE
Make wslpath to string

### DIFF
--- a/src/wsl.ts
+++ b/src/wsl.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 
 export function convertWslPathToWindows(p: string, distro: string): Promise<string> {
-  return runWslCommand(`wslpath -w ${p}`, distro);
+  return runWslCommand(`wslpath -w '${p}'`, distro);
 }
 
 function runWslCommand(command: string, distro: string): Promise<string> {


### PR DESCRIPTION
This PR fixes #28

---

https://github.com/Tyriar/vscode-windows-terminal/blob/d9f2f0c225bd7e986e3bc3a89e8ed9cd3e31fb72/src/wsl.ts#L4

I think the problem was that when there's a folder with spaces, the argument of the `wslpath` command gets _"separated"_ and therefore, gets an error because there's "more" arguments.

Putting simple quotation marks makes the entire path `${p}` literal, and therefore, if the path contain a folder with spaces in it, it don't get _"separated"_ from the argument.

Works for me at least.