### PR TITLE
Add setting to reuse an existing terminal window

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
             "Use the preview version of Windows Terminal"
           ]
         },
+        "windowsTerminal.reuseExistingWindow": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to reuse an existing Windows Terminal window."
+        },
         "windowsTerminal.explorer.showOpen": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,12 +39,18 @@ async function refreshInstallation(force: boolean = false) {
 }
 
 async function openWindowsTerminal(profile: IWTProfile, uri?: vscode.Uri) {
+  const config = vscode.workspace.getConfiguration('windowsTerminal');
+  const reuseWindow = config.get<boolean>('reuseExistingWindow');
+
   await refreshInstallation();
   if (!installation) {
     return;
   }
 
   const args = ['-p', profile.name];
+  if (reuseWindow) {
+    args.splice(0, 0, '-w', '0');
+  }
 
   // If there is no URI, set it to the first workspace folder
   if (!uri) {


### PR DESCRIPTION
This should fix #35 👍 

I just added a new boolean setting `reuseExistingWindow` that will insert the needed arguments into the `args` array and thus works for all profiles. I could only test it with the stuff that is available on my windows machine but I do not see where else it would not work, as the command line arguments are available on all platforms equally.